### PR TITLE
API/devices: 18-Jun-2022 RMX2020 release

### DIFF
--- a/API/changelogs/RMX2020.md
+++ b/API/changelogs/RMX2020.md
@@ -1,3 +1,7 @@
+# 18-June-2022
+- Synced with latest PixelOS source (Hotfix)
+- Upstreamed Kernel
+
 # 12-June-2022
 - Synced with latest PixelOS source
 - Upstreamed Kernel

--- a/API/devices/RMX2020.json
+++ b/API/devices/RMX2020.json
@@ -13,8 +13,8 @@
     "device_display_name": "Realme C3/Realme Narzo 10A",
     "device_display_codename": "RMX2020/RMX2027",
     "public_download": "https://sourceforge.net/projects/pixelos-releases/files/twelve/RMX2020/",
-    "last_updated": "12 June 2022",
-    "private_download_tag": "RMX2020_20220611_1936",
+    "last_updated": "18 June 2022",
+    "private_download_tag": "RMX2020_20220618_1258",
     "active": true,
     "xda": null,
     "customRecoveryRequired": true


### PR DESCRIPTION
Signed-off-by: Sarthak Roy <sarthakroy2002@gmail.com>
Change-Id: I0e134c40fa1d8ea9aa828fe567a277314314d3f3