### PR TITLE
API: hotdog: 29/07/2022

### DIFF
--- a/API/changelogs/hotdog.md
+++ b/API/changelogs/hotdog.md
@@ -1,0 +1,23 @@
+# 29-July-2022
+
+- Initial Android 12 release.
+- June vendor SPL.
+- EROFS is used for /system, /system_ext, /product, /odm and /vendor.
+- F2FS for /userdata in conjunction with F2FS Compression which uses LZ4 as its compression algorithm.
+- Updated relevant blobs from OOS 11.0.6.1.
+- Build OnePlus Gallery.
+- Add Tri-state UI overlay for alert slider.
+- Add Screen-Off FOD overlay for screen-off FOD.
+- Adapt status bar height to QPR3.
+- Update graphics and adreno blobs from lahaina 19300.
+- Switch back to opengl.
+- Limit AOD & Ambient Display refresh rate to 60Hz.
+- Use vibration patterns from OOS11.
+- Limit AOD & Ambient Display refresh rate to 60Hz.
+- Build Graphene Camera.
+- Enable FUSE Passthrough.
+- Build KProfiles Frontend.
+- Nuke QTI WFD.
+- LZ4 compression for ramdisk.
+- Flatten Apex and use EROFS for it.
+- Build with DragonHeart Kernel, GCC 12.1.0 and linked with LLD 15.0.0.

--- a/API/devices/hotdog.json
+++ b/API/devices/hotdog.json
@@ -11,9 +11,9 @@
     "version": "monthly",
     "device_display_name": "OnePlus 7T Pro",
     "device_display_codename": "hotdog",
-    "public_download": "",
-    "last_updated": "",
-    "private_download_tag": "",
+    "public_download": "https://sourceforge.net/projects/pixelos-releases/files/twelve/hotdog/",
+    "last_updated": "29 July 2022",
+    "private_download_tag": "hotdog_20220729_0023",
     "active": true,
-    "xda": null
+    "xda": "https://forum.xda-developers.com/t/rom-12-1-oneplus-7t-pro-official-pixelos-aosp-stable-29-07-2022.4474059/"
 }


### PR DESCRIPTION
- This marks the first ever release of PixelOS for OnePlus 7T Pro.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>